### PR TITLE
Add missing NegotiateAuthenticationStatusCode summaries

### DIFF
--- a/xml/System.Net.Security/NegotiateAuthenticationStatusCode.xml
+++ b/xml/System.Net.Security/NegotiateAuthenticationStatusCode.xml
@@ -154,7 +154,7 @@
       </ReturnValue>
       <MemberValue>15</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Validation of the impersonation level failed.</summary>
       </Docs>
     </Member>
     <Member MemberName="InvalidCredentials">
@@ -274,7 +274,7 @@
       </ReturnValue>
       <MemberValue>13</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Validation of RequiredProtectionLevel against negotiated protection level failed.</summary>
       </Docs>
     </Member>
     <Member MemberName="TargetUnknown">
@@ -294,7 +294,7 @@
       </ReturnValue>
       <MemberValue>14</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Validation of the target name failed.</summary>
       </Docs>
     </Member>
     <Member MemberName="UnknownCredentials">


### PR DESCRIPTION
## Summary

Add missing `NegotiateAuthenticationStatusCode` summaries. Text taken verbatim from [source documentation](https://github.com/dotnet/runtime/blob/26da83df77b2391d6a74a4f24b663dc2fb4eda3f/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthenticationStatusCode.cs).

Fixes dotnet/runtime#73851